### PR TITLE
V2 fixes & mbedTLS port

### DIFF
--- a/examples/selfhosted/profile/mbedtls_th_api/th_ecdh.c
+++ b/examples/selfhosted/profile/mbedtls_th_api/th_ecdh.c
@@ -9,75 +9,152 @@
  * If you received this EEMBC Benchmark Software without having a currently
  * effective EEMBC Benchmark License Agreement, you must discontinue use.
  */
-
-#include "mbedtls/mbedtls_config.h"
 #include "mbedtls/ecdh.h"
 #include "mbedtls/ecp.h"
 #include "th_util.h"
 
 #include "ee_ecdh.h"
 
+typedef struct {
+    mbedtls_ecp_group_id group;
+    mbedtls_ecdh_context ecdh_ctx;
+    mbedtls_ecp_keypair our_key;
+} th_mbedtls_ecdh_t;
+
 /**
- * Create the context passed between functions.
+ * @brief Creates a context and generates a key pair.
  *
- * Return EE_STATUS_OK or EE_STATUS_ERROR.
+ * @param pp_context - A pointer to a context pointer to be created
+ * @param group - See the `ee_ecdh_group_t` enum
+ * @return ee_status_t - EE_STATUS_OK or EE_STATUS_ERROR
  */
 ee_status_t
 th_ecdh_create(void **p_context // output: portable context
-)
+, ee_ecdh_group_t group)
 {
-    mbedtls_ecdh_context *p_ecdh;
+    int result = -1;
+    mbedtls_ecp_group_id group_id;
+    th_mbedtls_ecdh_t *p_ecdh;
 
-    p_ecdh = (mbedtls_ecdh_context *)th_malloc(sizeof(mbedtls_ecdh_context));
+    if (group == EE_P256R1)
+    {
+        group_id = MBEDTLS_ECP_DP_SECP256R1;
+    }
+    else if (group == EE_P384)
+    {
+        group_id = MBEDTLS_ECP_DP_SECP384R1;
+    }
+    else if (group == EE_C25519)
+    {
+        group_id = MBEDTLS_ECP_DP_CURVE25519;
+    }
+    else
+    {
+        th_printf("e-[unsupported curve in th_ecdh_create]\r\n");
+        return EE_STATUS_ERROR;
+    }
+
+    p_ecdh = (th_mbedtls_ecdh_t *)th_malloc(sizeof(th_mbedtls_ecdh_t));
     if (p_ecdh == NULL)
     {
         th_printf("e-[malloc() fail in th_ecdh_create]\r\n");
         return EE_STATUS_ERROR;
     }
+
+    p_ecdh->group = group_id;
+
+    mbedtls_ecdh_init(&p_ecdh->ecdh_ctx);
+    result = mbedtls_ecdh_setup(&p_ecdh->ecdh_ctx, p_ecdh->group);
+
+    if (result != 0)
+    {
+        th_printf("e-[unsupported curve in th_ecdh_create]\r\n");
+        mbedtls_ecdh_free(&p_ecdh->ecdh_ctx);
+        th_free(p_ecdh);
+        return EE_STATUS_ERROR;
+    }
+
+    // Create a keypair and use it for the DUT key
+    mbedtls_ecp_keypair_init(&p_ecdh->our_key);
+    result = mbedtls_ecp_gen_key(group_id, &p_ecdh->our_key,
+                                 mbedtls_fake_random, NULL);
+
+    if (result != 0)
+    {
+        th_printf("e-[cannot create key in th_ecdh_create]\r\n");
+        mbedtls_ecp_keypair_free(&p_ecdh->our_key);
+        mbedtls_ecdh_free(&p_ecdh->ecdh_ctx);
+        th_free(p_ecdh);
+        return EE_STATUS_ERROR;
+    }
+
+    result = mbedtls_ecdh_get_params(&p_ecdh->ecdh_ctx, &p_ecdh->our_key, MBEDTLS_ECDH_OURS);
+
+    if (result != 0)
+    {
+        th_printf("e-[cannot import key in th_ecdh_create]\r\n");
+        mbedtls_ecp_keypair_free(&p_ecdh->our_key);
+        mbedtls_ecdh_free(&p_ecdh->ecdh_ctx);
+        th_free(p_ecdh);
+        return EE_STATUS_ERROR;
+    }
+
     *p_context = (void *)p_ecdh;
     return EE_STATUS_OK;
 }
 
 /**
- * Load a 64-byte public key from a peer, big-endian; confim is on curve
+ * @brief Loads the peer public key for use in the secreat calc.
  *
- * return EE_STATUS_OK on success.
+ * @param p_context - The context from the `create` function
+ * @param p_pub - The public key buffer
+ * @param publen - Length of the public key buffer
+ * @return ee_status_t - EE_STATUS_OK or EE_STATUS_ERROR
  */
-ee_status_t
-load_public_peer_key(void *p_context, unsigned char *p_pub, size_t publen)
+ee_status_t th_ecdh_set_peer_public_key(void *        p_context,
+                                        uint8_t *     p_pub,
+                                        uint_fast32_t publen)
 {
-    mbedtls_ecdh_context *p_ecdh;
-    mbedtls_ecp_point     Q;
-    unsigned char         uncompressed_point_buffer[65];
+    mbedtls_ecdh_context *p_ecdh = &((th_mbedtls_ecdh_t *)p_context)->ecdh_ctx;
+    mbedtls_ecp_group_id  group_id = ((th_mbedtls_ecdh_t *)p_context)->group;
     int                   ret;
+    mbedtls_ecp_keypair   their_key;
 
-    p_ecdh = (mbedtls_ecdh_context *)p_context;
+    mbedtls_ecp_keypair_init(&their_key);
 
-    mbedtls_ecp_point_init(&Q);
-
-    // First byte for mbedtls_ecp_point_read_binary must be 0x04
-    uncompressed_point_buffer[0] = 0x04;
-    th_memcpy(&(uncompressed_point_buffer[1]), p_pub, publen);
-
-    ret = mbedtls_ecp_point_read_binary(
-        &p_ecdh->grp, &Q, uncompressed_point_buffer, 65);
+    // Until MbedTLS exposes functions to handle public keys, we need to reach down
+    ret = mbedtls_ecp_group_load(&their_key.MBEDTLS_PRIVATE(grp), group_id);
     if (ret != 0)
     {
+        mbedtls_ecp_keypair_free(&their_key);
+        th_printf("e-[mbedtls_ecp_group_load: -0x%04x]\r\n", -ret);
+        return EE_STATUS_ERROR;
+    }
+
+    ret = mbedtls_ecp_point_read_binary(
+        &their_key.MBEDTLS_PRIVATE(grp), &their_key.MBEDTLS_PRIVATE(Q),
+        p_pub, publen);
+    if (ret != 0)
+    {
+        mbedtls_ecp_keypair_free(&their_key);
         th_printf("e-[mbedtls_ecp_point_read_binary: -0x%04x]\r\n", -ret);
         return EE_STATUS_ERROR;
     }
 
-    ret = mbedtls_ecp_check_pubkey(&p_ecdh->grp, &Q);
+    /*
+    ret = mbedtls_ecp_check_pubkey(&their_key.MBEDTLS_PRIVATE(grp), &their_key.MBEDTLS_PRIVATE(Q));
     if (ret != 0)
     {
         th_printf("e-[mbedtls_ecp_check_pubkey: -0x%04x]\r\n", -ret);
         return EE_STATUS_ERROR;
     }
+    */
 
-    ret = mbedtls_ecp_copy(&p_ecdh->Qp, &Q);
+    ret = mbedtls_ecdh_get_params(p_ecdh, &their_key, MBEDTLS_ECDH_THEIRS);
+    mbedtls_ecp_keypair_free(&their_key);
     if (ret != 0)
     {
-        th_printf("e-[mbedtls_ecp_copy: -0x%04x]\r\n", -ret);
+        th_printf("e-[mbedtls_ecdh_get_params: -0x%04x]\r\n", -ret);
         return EE_STATUS_ERROR;
     }
 
@@ -85,90 +162,32 @@ load_public_peer_key(void *p_context, unsigned char *p_pub, size_t publen)
 }
 
 /**
- * Load private & populate ecdh->Q public point
- */
-ee_status_t
-load_private_key(void *p_context, unsigned char *p_private, size_t prilen)
-{
-    int                   ret;
-    mbedtls_ecdh_context *p_ecdh;
-    mbedtls_ecp_group *   p_grp;
-
-    p_ecdh = (mbedtls_ecdh_context *)p_context;
-    p_grp  = &p_ecdh->grp;
-
-    ret = mbedtls_mpi_read_binary(&p_ecdh->d, p_private, prilen);
-    if (ret != 0)
-    {
-        th_printf("e-[mbedtls_mpi_read_binary: -0x%04x]\r\n", -ret);
-        return EE_STATUS_ERROR;
-    }
-
-    // compute the public key from the provided secret
-    mbedtls_ecp_point_init(&p_ecdh->Q);
-    ret = mbedtls_ecp_mul(
-        p_grp,
-        &p_ecdh->Q,          // R <-- this value will be computed as P * m
-        &p_ecdh->d,          // m
-        &p_grp->G,           // P
-        mbedtls_fake_random, // random function
-        0);
-    if (ret != 0)
-    {
-        th_printf("e-[mbedtls_ecp_mul: -0x%04x]\r\n", -ret);
-        return EE_STATUS_ERROR;
-    }
-
-    return EE_STATUS_OK;
-}
-
-/**
- * Initialize to a group (must be in the EE_ enum)
+ * @brief Returns the DUT's public key so that the HOST can verify
+ * the secret with it's private key.
  *
- * Return EE_STATUS_OK or EE_STATUS_ERROR.
+ * @param p_context - The context from the `create` function
+ * @param p_pub - The public key buffer
+ * @param p_publen - Length of the public key buffer
+ * @return ee_status_t - EE_STATUS_OK or EE_STATUS_ERROR
  */
-ee_status_t
-th_ecdh_init(void *        p_context, // input: portable context
-             ee_ecdh_group_t  group,     // input: see `ee_ecdh_group_t` for options
-             uint8_t *     p_private, // input: private key, from host
-             uint_fast32_t prilen,    // input: private key length in bytes
-             uint8_t *     p_public,  // input: peer public key, from host
-             uint_fast32_t publen     // input: peer public key length in bytes
-)
+ee_status_t th_ecdh_get_public_key(void *         p_context,
+                                   uint8_t *      p_pub,
+                                   uint_fast32_t *p_publen)
 {
-    mbedtls_ecdh_context *p_ecdh;
-    int                   ret;
+    mbedtls_ecp_keypair    *p_our_key = &((th_mbedtls_ecdh_t *)p_context)->our_key;
+    int                     ret;
+    size_t                  olen;
 
-    p_ecdh = (mbedtls_ecdh_context *)p_context;
-    switch (group)
+    // Until MbedTLS exposes functions to handle public keys, we need to reach down
+    ret = mbedtls_ecp_point_write_binary(&p_our_key->MBEDTLS_PRIVATE(grp), &p_our_key->MBEDTLS_PRIVATE(Q),
+                                         MBEDTLS_ECP_PF_UNCOMPRESSED, &olen, p_pub, *p_publen);
+    if (ret != 0)
     {
-        case EE_P256R1:
-            mbedtls_ecdh_init(p_ecdh);
-            ret = mbedtls_ecp_group_load(&p_ecdh->grp,
-                                         MBEDTLS_ECP_DP_SECP256R1);
-            if (ret)
-            {
-                th_printf("e-[mbedtls_ecp_group_load: -0x%04x]\r\n", -ret);
-                return EE_STATUS_ERROR;
-            }
-            break;
-        default:
-            th_printf("e-[Invalid ECC curve in th_ecdh_init]\r\n");
-            return EE_STATUS_ERROR;
-    }
-    ret = load_public_peer_key(p_context, p_public, publen);
-    if (ret != EE_STATUS_OK)
-    {
-        th_printf("e-[load_public_peer_key: -0x%04x]\r\n", -ret);
+        th_printf("e-[mbedtls_ecp_point_write_binary: -0x%04x]\r\n", -ret);
         return EE_STATUS_ERROR;
     }
 
-    ret = load_private_key(p_context, p_private, prilen);
-    if (ret != EE_STATUS_OK)
-    {
-        th_printf("e-[load_private_key: -0x%04x]\r\n", -ret);
-        return EE_STATUS_ERROR;
-    }
+    *p_publen = olen;
 
     return EE_STATUS_OK;
 }
@@ -180,43 +199,26 @@ th_ecdh_init(void *        p_context, // input: portable context
  */
 ee_status_t
 th_ecdh_calc_secret(
-    void *        p_context, // input: portable context
-    uint8_t *     p_secret,  // output: shared secret
-    uint_fast32_t slen       // input: length of shared buffer in bytes
+    void *         p_context, // input: portable context
+    uint8_t *      p_secret,  // output: shared secret
+    uint_fast32_t *p_seclen   // input/output: length of shared buffer in bytes
 )
 {
     mbedtls_ecdh_context *p_ecdh;
     size_t                olen;
     int                   ret;
 
-    p_ecdh = (mbedtls_ecdh_context *)p_context;
-    /**
-     * For the MBEDTLS_ECP_DP_SECP256R1 the buffer must be equal to or larger
-     * than 32 bytes.
-     */
-    // TODO: Magic number
-    if (slen < 32u)
-    {
-        th_printf("e-[Secret buffer too small: %u < 32]\r\n", slen);
-        return EE_STATUS_ERROR;
-    }
+    p_ecdh = &((th_mbedtls_ecdh_t *)p_context)->ecdh_ctx;
+
     ret = mbedtls_ecdh_calc_secret(
-        p_ecdh, &olen, p_secret, slen, mbedtls_fake_random, NULL);
+        p_ecdh, &olen, p_secret, *p_seclen, mbedtls_fake_random, NULL);
     if (ret != 0)
     {
         th_printf("e-[mbedtls_ecdh_calc_secret: 0x%04x]\r\n", ret);
         return EE_STATUS_ERROR;
     }
-    /**
-     * Must be the same size as the curve size; for example, if the curve is
-     * secp256r1, secret must be 32 bytes long.
-     */
-    // TODO: Magic number
-    if (olen != 32u)
-    {
-        th_printf("e-[Output length isn 32B: %lu]\r\n", olen);
-        return EE_STATUS_ERROR;
-    }
+
+    *p_seclen = olen;
 
     return EE_STATUS_OK;
 }
@@ -228,6 +230,7 @@ void
 th_ecdh_destroy(void *p_context // input: portable context
 )
 {
-    mbedtls_ecdh_free((mbedtls_ecdh_context *)p_context);
+    mbedtls_ecp_keypair_free(&((th_mbedtls_ecdh_t *)p_context)->our_key);
+    mbedtls_ecdh_free(&((th_mbedtls_ecdh_t *)p_context)->ecdh_ctx);
     th_free(p_context);
 }

--- a/examples/selfhosted/profile/mbedtls_th_api/th_ecdsa.c
+++ b/examples/selfhosted/profile/mbedtls_th_api/th_ecdsa.c
@@ -13,148 +13,272 @@
 #include "mbedtls/mbedtls_config.h"
 #include "mbedtls/ecdsa.h"
 
-#include "ee_ecdh.h"
 #include "ee_ecdsa.h"
 #include "th_util.h"
 
-// helper function defined in th_ecdh.h; not mandatory but very useful!
-int load_private_key(void *, unsigned char *, size_t);
+typedef struct {
+    mbedtls_ecp_group_id group;
+    mbedtls_ecdsa_context ecdsa_ctx;
+    mbedtls_ecp_keypair our_key;
+} th_mbedtls_ecdsa_t;
 
 /**
- * Create the context passed between functions.
+ * @brief Creates a context and generates a key pair.
  *
- * Return EE_STATUS_OK or EE_STATUS_ERROR.
+ * @param pp_context - A pointer to a context pointer to be created.
+ * @param group - See the `ee_ecdh_group_t` enum
+ * @return ee_status_t - EE_STATUS_OK or EE_STATUS_ERROR
  */
-ee_status_t
-th_ecdsa_create(void **p_context // output: portable context
-)
+ee_status_t th_ecdsa_create(void **pp_context, ee_ecdh_group_t group)
 {
-    mbedtls_ecdsa_context *p_ecdsa;
+    th_mbedtls_ecdsa_t     *p_ecdsa;
+    mbedtls_ecp_group_id    group_id;
+    int                     result;
 
-    p_ecdsa = (mbedtls_ecdsa_context *)th_malloc(sizeof(mbedtls_ecdsa_context));
+    switch (group)
+    {
+        case EE_P256R1:
+            group_id = MBEDTLS_ECP_DP_SECP256R1;
+            break;
+        case EE_P384:
+            group_id = MBEDTLS_ECP_DP_SECP384R1;
+            break;
+        default:
+            th_printf("e-[unsupported curve in th_ecdsa_create]\r\n");
+            return EE_STATUS_ERROR;
+    }
+
+    p_ecdsa = (th_mbedtls_ecdsa_t *)th_malloc(sizeof(th_mbedtls_ecdsa_t));
     if (p_ecdsa == NULL)
     {
         th_printf("e-[malloc() fail in th_ecdsa_create]\r\n");
         return EE_STATUS_ERROR;
     }
-    *p_context = (void *)p_ecdsa;
+
+    // Generate keypair
+    mbedtls_ecp_keypair_init(&p_ecdsa->our_key);
+    result = mbedtls_ecp_gen_key(group_id, &p_ecdsa->our_key,
+                                 mbedtls_fake_random, NULL);
+
+    if (result != 0)
+    {
+        th_printf("e-[cannot create key in th_ecdsa_create]\r\n");
+        mbedtls_ecp_keypair_free(&p_ecdsa->our_key);
+        th_free(p_ecdsa);
+        return EE_STATUS_ERROR;
+    }
+
+    // Create ECDSA context from keypair
+    mbedtls_ecdsa_init(&p_ecdsa->ecdsa_ctx);
+    result = mbedtls_ecdsa_from_keypair(&p_ecdsa->ecdsa_ctx, &p_ecdsa->our_key);
+    if (result != 0)
+    {
+        th_printf("e-[cannot create key in th_ecdsa_create]\r\n");
+        mbedtls_ecdsa_free(&p_ecdsa->ecdsa_ctx);
+        mbedtls_ecp_keypair_free(&p_ecdsa->our_key);
+        th_free(p_ecdsa);
+        return EE_STATUS_ERROR;
+    }
+
+    p_ecdsa->group = group_id;
+
+    *pp_context = (void *)p_ecdsa;
     return EE_STATUS_OK;
 }
 
 /**
- * Initialize to a group (must be in the EE_ enum) with a predefined
- * private key.
+ * @brief Deallocate/destroy the context
  *
- * Return EE_STATUS_OK or EE_STATUS_ERROR.
+ * @param p_context - The context from the `create` function
  */
-ee_status_t
-th_ecdsa_init(void *        p_context, // input: portable context
-              ee_ecdh_group_t  group,     // input: see `ee_ecdh_group_t` for options
-              uint8_t *     p_private, // input: private key from host
-              uint_fast32_t plen       // input: length of private key in bytes
-)
+void th_ecdsa_destroy(void *p_context)
 {
-    mbedtls_ecdsa_context *p_ecdsa;
-    int                    ret;
+    mbedtls_ecp_keypair_free(&((th_mbedtls_ecdsa_t *)p_context)->our_key);
+    mbedtls_ecdsa_free(&((th_mbedtls_ecdsa_t *)p_context)->ecdsa_ctx);
+    th_free(p_context);
+}
 
-    p_ecdsa = (mbedtls_ecdsa_context *)p_context;
-    mbedtls_ecdsa_init(p_ecdsa);
-    switch (group)
+/**
+ * @brief Return the public key generated during `th_ecdsa_create`.
+ *
+ * @param p_context - The context from the `create` function
+ * @param p_out - Buffer to receive the public key
+ * @param p_outlen - Number of bytes used in the buffer
+ * @return ee_status_t - EE_STATUS_OK or EE_STATUS_ERROR
+ */
+ee_status_t th_ecdsa_get_public_key(void *         p_context,
+                                    uint8_t *      p_out,
+                                    uint_fast32_t *p_outlen)
+{
+    mbedtls_ecp_keypair    *p_our_key = &((th_mbedtls_ecdsa_t *)p_context)->our_key;
+    int                     ret;
+    size_t                  olen;
+
+    // Until MbedTLS exposes functions to handle public keys, we need to reach down
+    ret = mbedtls_ecp_point_write_binary(&p_our_key->MBEDTLS_PRIVATE(grp), &p_our_key->MBEDTLS_PRIVATE(Q),
+                                         MBEDTLS_ECP_PF_UNCOMPRESSED, &olen, p_out, *p_outlen);
+    if (ret != 0)
     {
-        case EE_P256R1:
-            ret = mbedtls_ecp_group_load(&p_ecdsa->grp,
-                                         MBEDTLS_ECP_DP_SECP256R1);
-            if (ret != 0)
-            {
-                th_printf("e-[Failed to ECDSA init: 0x%04x]\r\n", ret);
-                return EE_STATUS_ERROR;
-            }
+        th_printf("e-[mbedtls_ecp_point_write_binary: -0x%04x]\r\n", -ret);
+        return EE_STATUS_ERROR;
+    }
+
+    *p_outlen = olen;
+
+    return EE_STATUS_OK;
+}
+
+/**
+ * @brief Set the public key in the context in order to perform a verify.
+ *
+ * For EcDSA, the key shall be in SECP1 uncompressed format { 04 | X | Y }.
+ *
+ * @param p_context - The context from the `create` function
+ * @param p_pub - The public key buffer
+ * @param publen - Length of the public key buffer
+ * @return ee_status_t - EE_STATUS_OK or EE_STATUS_ERROR
+ */
+ee_status_t th_ecdsa_set_public_key(void *        p_context,
+                                    uint8_t *     p_pub,
+                                    uint_fast32_t publen)
+{
+    mbedtls_ecdsa_context  *p_ecdsa = &((th_mbedtls_ecdsa_t *)p_context)->ecdsa_ctx;
+    mbedtls_ecp_group_id    group_id = ((th_mbedtls_ecdsa_t *)p_context)->group;
+    int                     ret;
+    mbedtls_ecp_keypair     their_key;
+
+    mbedtls_ecp_keypair_init(&their_key);
+
+    // Until MbedTLS exposes functions to handle public keys, we need to reach down
+    ret = mbedtls_ecp_group_load(&their_key.MBEDTLS_PRIVATE(grp), group_id);
+    if (ret != 0)
+    {
+        mbedtls_ecp_keypair_free(&their_key);
+        th_printf("e-[mbedtls_ecp_group_load: -0x%04x]\r\n", -ret);
+        return EE_STATUS_ERROR;
+    }
+
+    ret = mbedtls_ecp_point_read_binary(
+        &their_key.MBEDTLS_PRIVATE(grp), &their_key.MBEDTLS_PRIVATE(Q),
+        p_pub, publen);
+    if (ret != 0)
+    {
+        mbedtls_ecp_keypair_free(&their_key);
+        th_printf("e-[mbedtls_ecp_point_read_binary: -0x%04x]\r\n", -ret);
+        return EE_STATUS_ERROR;
+    }
+
+    /*
+    ret = mbedtls_ecp_check_pubkey(&their_key.MBEDTLS_PRIVATE(grp), &their_key.MBEDTLS_PRIVATE(Q));
+    if (ret != 0)
+    {
+        th_printf("e-[mbedtls_ecp_check_pubkey: -0x%04x]\r\n", -ret);
+        return EE_STATUS_ERROR;
+    }
+    */
+
+    ret = mbedtls_ecdsa_from_keypair(p_ecdsa, &their_key);
+    mbedtls_ecp_keypair_free(&their_key);
+    if (ret != 0)
+    {
+        th_printf("e-[mbedtls_ecdh_get_params: -0x%04x]\r\n", -ret);
+        return EE_STATUS_ERROR;
+    }
+
+    return EE_STATUS_OK;
+}
+
+/**
+ * @brief Sign a message (hash) with the private key.
+ *
+ * For EcDSA, the signature format is the ASN.1 DER of R and S. For Ed25519,
+ * the signature is the raw, little endian encoding of R and S, padded to 256
+ * bits.
+ *
+ * Note that even if the message is a hash, Ed25519 will perform another SHA-
+ * 512 operation on it, as this is part of RFC 8032.
+ *
+ * `p_siglen` should point to the buffer size on input; on return it will
+ * contain the length of the signature.
+ *
+ * @param p_context - The context from the `create` function
+ * @param p_msg - The hashed buffer to sign
+ * @param msglen - Length of the hashed buffer
+ * @param p_sig - The output signature buffer (provided)
+ * @param p_siglen - The number of bytes used in the output signature buffer.
+ * @return ee_status_t - EE_STATUS_OK or EE_STATUS_ERROR
+ */
+ee_status_t th_ecdsa_sign(void *         p_context,
+                          uint8_t *      p_msg,
+                          uint_fast32_t  msglen,
+                          uint8_t *      p_sig,
+                          uint_fast32_t *p_siglen)
+{
+    mbedtls_ecdsa_context  *p_ecdsa = &((th_mbedtls_ecdsa_t *)p_context)->ecdsa_ctx;
+    mbedtls_ecp_group_id    group_id = ((th_mbedtls_ecdsa_t *)p_context)->group;
+    mbedtls_md_type_t       md_type;
+    int                     result;
+    size_t                  olen;
+
+    switch (group_id)
+    {
+        case MBEDTLS_ECP_DP_SECP256R1:
+            md_type = MBEDTLS_MD_SHA256;
+            break;
+        case MBEDTLS_ECP_DP_SECP384R1:
+            md_type = MBEDTLS_MD_SHA384;
             break;
         default:
-            th_printf("e-[Invalid ECC curve in th_ecdsa_init]\r\n");
+            th_printf("e-[Unsupported curve in th_ecdsa_sign]\r\n");
             return EE_STATUS_ERROR;
     }
 
-    // load the private key and generate our own public key
-    return load_private_key(p_context, p_private, plen);
-}
-
-/**
- * Create a signature using the specified hash.
- *
- * Return EE_STATUS_OK or EE_STATUS_ERROR.
- */
-ee_status_t
-th_ecdsa_sign(void *         p_context, // input: portable context
-              uint8_t *      p_hash,    // input: sha256 digest
-              uint_fast32_t  hlen,      // input: length of digest in bytes
-              uint8_t *      p_sig,     // output: signature
-              uint_fast32_t *p_slen // in/out: input=MAX slen, output=resultant
-)
-{
-    mbedtls_ecdsa_context *p_ecdsa;
-    size_t                 slent;
-    int                    ret;
-
-    p_ecdsa = (mbedtls_ecdsa_context *)p_context;
-    // WARNING: Copy *slen into local storage if your SDK size type is
-    //          not the same size as "unsigned int" and recast on assignment.
-    slent = *p_slen;
-
-    ret = mbedtls_ecdsa_write_signature(p_ecdsa,
-                                        MBEDTLS_MD_SHA256,
-                                        p_hash,
-                                        hlen,
-                                        p_sig,
-                                        slent,
-                                        &slent,
-                                        mbedtls_fake_random,
-                                        NULL);
-
-    if (ret != 0)
+    result = mbedtls_ecdsa_write_signature(p_ecdsa, md_type,
+                                           p_msg, msglen,
+                                           p_sig, *p_siglen, &olen,
+                                           mbedtls_fake_random, NULL);
+    if (result != 0)
     {
-        th_printf("e-[Failed to sign in th_ecdsa_sign: 0x%04x]\r\n", ret);
+        th_printf("e-[mbedtls_ecdsa_write_signature: -0x%04x]\r\n", -result);
         return EE_STATUS_ERROR;
     }
 
-    *p_slen = (unsigned int)slent;
+    *p_siglen = olen;
     return EE_STATUS_OK;
 }
 
 /**
- * Create a signature using SHA256 hash.
+ * @brief Verify a message (hash) with the public key.
  *
- * Return EE_STATUS_OK or EE_STATUS_ERROR.
+ * It will return EE_STATUS_OK on message verify, and EE_STATUS_ERROR if the
+ * message does not verify, or if there is some other error (which shall
+ * be reported with `th_printf("e-[....]r\n");`.
+ *
+ * @param p_context - The context from the `create` function
+ * @param group - See the `ee_ecdh_group_t` enum
+ * @param p_hash - The hashed buffer to verify
+ * @param hlen - Length of the hashed buffer
+ * @param p_sig - The input signature buffer
+ * @param slen - Length of the input signature buffer
+ * @return ee_status_t - see above.
  */
-ee_status_t
-th_ecdsa_verify(void *        p_context, // input: portable context
-                uint8_t *     p_hash,    // input: sha256 digest
-                uint_fast32_t hlen,      // input: length of digest in bytes
-                uint8_t *     p_sig,     // output: signature
-                uint_fast32_t slen       // input: length of signature in bytes
-)
+ee_status_t th_ecdsa_verify(void *        p_context,
+                            uint8_t *     p_msg,
+                            uint_fast32_t msglen,
+                            uint8_t *     p_sig,
+                            uint_fast32_t siglen)
 {
-    mbedtls_ecdsa_context *p_ecdsa;
-    int                    ret;
+    mbedtls_ecdsa_context  *p_ecdsa = &((th_mbedtls_ecdsa_t *)p_context)->ecdsa_ctx;
+    int                     result;
 
-    p_ecdsa = (mbedtls_ecdsa_context *)p_context;
-    ret     = mbedtls_ecdsa_read_signature(p_ecdsa, p_hash, hlen, p_sig, slen);
-
-    if (ret != 0)
+    result = mbedtls_ecdsa_read_signature(p_ecdsa,
+                                          p_msg, msglen,
+                                          p_sig, siglen);
+    if (result != 0)
     {
-        th_printf("e-[Failed to verify in th_ecdsa_verify: 0x%04x]\r\n", ret);
+        th_printf("e-[mbedtls_ecdsa_read_signature: -0x%04x]\r\n", -result);
         return EE_STATUS_ERROR;
     }
-    return EE_STATUS_OK;
-}
 
-/**
- * Destroy the context created earlier.
- */
-void
-th_ecdsa_destroy(void *p_context // portable context
-)
-{
-    mbedtls_ecdsa_free((mbedtls_ecdsa_context *)p_context);
-    th_free(p_context);
+    return EE_STATUS_OK;
 }

--- a/examples/selfhosted/profile/mbedtls_th_api/th_rsa.c
+++ b/examples/selfhosted/profile/mbedtls_th_api/th_rsa.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) EEMBC(R). All Rights Reserved
+ *
+ * All EEMBC Benchmark Software are products of EEMBC and are provided under the
+ * terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
+ * are proprietary intellectual properties of EEMBC and its Members and is
+ * protected under all applicable laws, including all applicable copyright laws.
+ *
+ * If you received this EEMBC Benchmark Software without having a currently
+ * effective EEMBC Benchmark License Agreement, you must discontinue use.
+ */
+
+#include "ee_main.h"
+#include "th_lib.h"
+#include "th_libc.h"
+#include "th_util.h"
+
+ee_status_t
+th_rsa_create(void **pp_context)
+{
+#warning "th_rsa_create not implemented"
+    return EE_STATUS_OK;
+}
+
+ee_status_t
+th_rsa_set_public_key(void *         p_context,
+                      const uint8_t *p_pub,
+                      uint_fast32_t  publen)
+{
+#warning "th_rsa_set_public_key not implemented"
+    return EE_STATUS_OK;
+}
+
+ee_status_t
+th_rsa_verify(void *        p_context,
+              uint8_t *     p_msg,
+              uint_fast32_t mlen,
+              uint8_t *     p_sig,
+              uint_fast32_t slen,
+              uint8_t *     p_verify)
+{
+#warning "th_rsa_sign not implemented"
+    return EE_STATUS_OK;
+}
+
+ee_status_t
+th_rsa_destroy(void *p_context)
+{
+#warning "th_rsa_destroy not implemented"
+    return EE_STATUS_OK;
+}

--- a/examples/selfhosted/profile/mbedtls_th_api/th_util.c
+++ b/examples/selfhosted/profile/mbedtls_th_api/th_util.c
@@ -12,8 +12,6 @@
 
 #include "th_util.h"
 
-// NOTE: Feel free to replace the static variable with any allocation scheme
-#define BUFFER_SIZE (1024 * 4)
 static unsigned char g_generic_buffer[BUFFER_SIZE];
 
 /**

--- a/examples/selfhosted/profile/mbedtls_th_api/th_util.h
+++ b/examples/selfhosted/profile/mbedtls_th_api/th_util.h
@@ -13,15 +13,69 @@
 #ifndef __TH_UTIL_H
 #define __TH_UTIL_H
 
+#include <ee_main.h>
 #include <stddef.h>
 #include <stdint.h>
 
+/* PORTME: Update this if/elif so that the endina macros are correct. */
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN                    \
+    || defined(__BIG_ENDIAN__) || defined(__ARMEB__) || defined(__THUMBEB__) \
+    || defined(__AARCH64EB__) || defined(_MIBSEB) || defined(__MIBSEB)       \
+    || defined(__MIBSEB__)
+#define EE_FIX_ENDIAN(x) bswap32(x)
+#define
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN            \
+    || defined(__LITTLE_ENDIAN__) || defined(__ARMEL__)                   \
+    || defined(__THUMBEL__) || defined(__AARCH64EL__) || defined(_MIPSEL) \
+    || defined(__MIPSEL) || defined(__MIPSEL__)
+#define EE_FIX_ENDIAN(x) (x)
+#else
+#error "I don't know what architecture this is!"
+#endif
+
+#define BUFFER_SIZE (1024 * 8)
+
+/**
+ * @brief Most init can happen prior to ee_main(), but if necessary, this
+ * function provides a way to initialize within the ee_* initialization. It is
+ * called from: ee_main() > ee_profile_init() > th_profile_init().
+ *
+ * @return ee_status_t
+ */
+ee_status_t th_profile_initialize(void);
+
+/**
+ * @brief Perform any power-reducing opportinuties before entering a compute-
+ * intensive loop.
+ */
 void th_pre(void);
+
+/**
+ * @brief Undo any power-reducing opportinuties set with `th_pre()`.
+ */
 void th_post(void);
 
-void           th_buffer_initialize(void);
-unsigned char *th_buffer_address(void);
-size_t         th_buffer_size(void);
+/**
+ * @brief If memory is located somewhere other than a heap, it needs to be
+ * content addressible with `[]` operator. This may need to be deprecated,
+ * as it has never been used.
+ *
+ */
+void th_buffer_initialize(void);
+
+/**
+ * @brief If non-heap memory is used, return a `[]` addressible pointer.
+ *
+ * @return uint8_t* - Pointer to the start of the generic buffer.
+ */
+uint8_t *th_buffer_address(void);
+
+/**
+ * @brief Returns the size of the buffer.
+ *
+ * @return uint_fast32_t - The size of the buffer.
+ */
+uint_fast32_t th_buffer_size(void);
 
 /* mbedTLS 3.0.0 requires a random function for ECC, we don't
  * care about how good it is. */

--- a/monitor/th_api/th_libc.c
+++ b/monitor/th_api/th_libc.c
@@ -68,6 +68,12 @@ th_memcpy(void *dst, const void *src, size_t n)
 }
 
 void *
+th_memmove(void *dst, const void *src, size_t n)
+{
+    return memmove(dst, src, n);
+}
+
+void *
 th_malloc(size_t size)
 {
     return malloc(size);

--- a/monitor/th_api/th_libc.h
+++ b/monitor/th_api/th_libc.h
@@ -28,6 +28,7 @@ char *th_strtok(/*@null@*/ char *str1, const char *sep);
 int   th_atoi(const char *str);
 void *th_memset(void *b, int c, size_t len);
 void *th_memcpy(void *dst, const void *src, size_t n);
+void *th_memmove(void *dst, const void *src, size_t n);
 /*@null@*/ /*@out@*/
 void *th_malloc(size_t size);
 /*@null@*/ /*@out@*/

--- a/profile/ee_bench.c
+++ b/profile/ee_bench.c
@@ -214,6 +214,8 @@ ee_bench_ecdsa_sign(ee_ecdh_group_t g,
     th_pre();
     do
     {
+        // reset siglen back to maximum for each round, since output length may vary
+        siglen = 256;
         ret = th_ecdsa_sign(p_context, p_msg, n, p_sig, &siglen);
     } while (--i > 0 && ret == EE_STATUS_OK);
     th_post();

--- a/profile/ee_sha.c
+++ b/profile/ee_sha.c
@@ -33,14 +33,14 @@ ee_sha(ee_sha_size_t  size,
     th_printf("m-sha%d-start\r\n", size);
     t0 = th_timestamp();
     th_pre();
-    if (th_sha_init(p_context) != EE_STATUS_OK)
-    {
-        th_post();
-        th_printf("e-sha%d-[Failed to initialize]\r\n", size);
-        goto exit;
-    }
     while (iter-- > 0)
     {
+        if (th_sha_init(p_context) != EE_STATUS_OK)
+        {
+            th_post();
+            th_printf("e-sha%d-[Failed to initialize]\r\n", size);
+            goto exit;
+        }
         if (th_sha_process(p_context, p_in, len) != EE_STATUS_OK)
         {
             th_post();


### PR DESCRIPTION
Commits, in order:

- Added libc `memmove` (memcpy for overlapping buffers)
- Fixed the bench loop for ECDSA signatures, where the function called has a length in/out parameter which wasn't reset to the original value before each call. ECDSA signatures in ASN.1 format are variable length depending on the amount of leading zero bits in the r/s components, so when generating non-deterministic signatures, the function could fail when fed the output length of the previous call as total length of the buffer.
- Fixed the paradigm for testing SHA processing. The mbedTLS and PSA APIs consider a SHA context invalid after `done` has been called on it, so in order to do a new iteration of `process`, we also need to issue a new iteration of `init`. Alternatively move the call to `done` out of the loop again, but as that was what had been changed from v1 to begin with, I assumed the intent is to run a full operation on each iteration, not add multiple iterations of the same data to a single hash.
- Redid the mbedTLS test harness to match the v2 API.